### PR TITLE
Fix webhook cache to not allow multiple entries per key

### DIFF
--- a/apps/vmq_webhooks/src/vmq_webhooks_cache.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_cache.erl
@@ -35,7 +35,7 @@
 %% API
 -spec new() -> 'ok'.
 new() ->
-    ets:new(?CACHE, [public, bag, named_table, {read_concurrency, true}]),
+    ets:new(?CACHE, [public, set, named_table, {read_concurrency, true}]),
     ets:new(?STATS, [public, ordered_set, named_table, {write_concurrency, true}]),
     ok.
 


### PR DESCRIPTION
When many client requests with identical client ids are arriving almost in
parallel, it could happen that multiple requests are processed in parallel.
Nevertheless, those requests must not lead to multiple cache entries per
key, as this would crash the lookup function with the below error message.
Changing the ets storage table type from a `bag` to a `set` is apparently
already sufficient to achieve this.

This is the error message occurring before this change, which did no
longer occur after this change. Notice how the crash is caused by a
non-matching case in vmq_webhooks_cache:lookup_/3 line 88:

13:02:18.953 [error] CRASH REPORT Process <0.2338.0> with 0 neighbours crashed
with reason: no case clause matching [{{<<"https://someserver:443/api/broker/auth/register">>,
auth_on_register,[{addr,<<"172.21.0.7">>},{mountpoint,<<"password">>},{client_id,<<"client11">>},
{username,<<"someuser">>},{password,<<"somepassword">>},{clean_session,true}]},
{<<"password">>,<<"client11">>},1652447234,[{mountpoint,<<>>},{client_id,<<"client11">>}]},
{{<<"https://someserver:443/api/broker/auth/register">>,
auth_on_register,[{addr,<<"172.21.0.7">>},{mountpoint,<<"password">>},{client_id,<<"client11">>},
{username,<<"someuser">>},{password,...},...]},...}]
in vmq_webhooks_cache:lookup_/3 line 88
